### PR TITLE
Fix an invalid file path in the Copy File build phase

### DIFF
--- a/Loading.xcodeproj/project.pbxproj
+++ b/Loading.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0AE84ED01AF8FE5600DA38AC /* Loader.app in CopyFiles */ = {isa = PBXBuildFile; fileRef = 574632031A74C6EF006E6212 /* Loader.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		57243A7C1A78C9F8009855CA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 57243A7E1A78C9F8009855CA /* Localizable.strings */; };
 		572BFC881AD95D23005F76B3 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 572BFC871AD95D23005F76B3 /* MainMenu.xib */; };
 		575ADC401AC87C81009930BC /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 575ADC421AC87C81009930BC /* InfoPlist.strings */; };
@@ -17,7 +18,6 @@
 		578821331A6B52EC00702A7D /* AppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 578821321A6B52EC00702A7D /* AppRecord.m */; };
 		57EDFDB81A74C3BD00DEC6D6 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57EDFDB71A74C3BD00DEC6D6 /* Cocoa.framework */; };
 		57EDFDBC1A74C3D300DEC6D6 /* ServiceManagement.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57EDFDBB1A74C3D300DEC6D6 /* ServiceManagement.framework */; };
-		57EDFDC71A74C5D000DEC6D6 /* Loader.app in CopyFiles */ = {isa = PBXBuildFile; fileRef = 57EDFDC61A74C5D000DEC6D6 /* Loader.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,7 +46,7 @@
 			dstPath = Contents/Library/LoginItems;
 			dstSubfolderSpec = 1;
 			files = (
-				57EDFDC71A74C5D000DEC6D6 /* Loader.app in CopyFiles */,
+				0AE84ED01AF8FE5600DA38AC /* Loader.app in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -136,7 +136,6 @@
 		57EDFDB71A74C3BD00DEC6D6 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		57EDFDB91A74C3CB00DEC6D6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		57EDFDBB1A74C3D300DEC6D6 /* ServiceManagement.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ServiceManagement.framework; path = System/Library/Frameworks/ServiceManagement.framework; sourceTree = SDKROOT; };
-		57EDFDC61A74C5D000DEC6D6 /* Loader.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; name = Loader.app; path = "/Users/mikemcfadden/Library/Developer/Xcode/DerivedData/Loading-cxjhinzuwocusiasucoqdsacndby/Build/Products/Debug/Loader.app"; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -168,7 +167,6 @@
 				578821091A6B43D900702A7D /* Loading */,
 				5788212C1A6B44D500702A7D /* Frameworks */,
 				578821081A6B43D900702A7D /* Products */,
-				57EDFDC61A74C5D000DEC6D6 /* Loader.app */,
 			);
 			sourceTree = "<group>";
 		};


### PR DESCRIPTION
This PR changes `Loader.app` path from absolute to relative, so the build won't fail with the following error:

```
error:
/Users/mikemcfadden/Library/Developer/Xcode/DerivedData/Loading-cxjhinzu
wocusiasucoqdsacndby/Build/Products/Debug/Loader.app: No such file or
directory
```
