### PR TITLE
Update for German Localizable.strings

### DIFF
--- a/Loading/de.lproj/Localizable.strings
+++ b/Loading/de.lproj/Localizable.strings
@@ -1,1 +1,31 @@
-"APPLICATION_NOT_RESPONDING" = "Programm reagiert nicht";"PREFS" = "Einstellungen...";"DISPLAY_AS" = "Anzeigen als";"HIDE" = "Ausblenden";"HIDE_NAME" = "%@ ausblenden";"HIDE_OTHERS" = "Andere ausblenden";"OPEN_AT_LOGIN" = "Bei der Anmeldung öffnen";"OPTIONS" = "Optionen";"QUIT" = "Beenden";"SHOW_IN_FINDER" = "Im Finder anzeigen";"SORT_BY" = "Sortiert nach";"TURN_NOTIFICATIONS_OFF" = "Benachrichtigungen ausschalten";"TURN_NOTIFICATIONS_ON" = "Benachrichtigungen einschalten";"WELCOME_TO_LOADING" = "Willkommen bei Loading!";"LOADING_INTRO" = "Loading zeigt Ihnen, wann Apps nutzen das Internet. Haben Sie es zu öffnen, wenn Sie sich anmelden wollen?";"CANCEL" = "Abbrechen";"LOADING" = "Laden";"LOADED" = "Beladen";"APPLICATIONS" = "Programme";"SYSTEM" = "System";"CHECK_FOR_UPDATES" = "Nach Updates suchen";"SEND_FEEDBACK" = "Feedback geben...";"ABOUT" = "Über %@";"THANKS" = "Vielen Dank!";"MORE_INFO" = "Weitere Infos...";"DOWNLOAD" = "Laden";"NAME" = "Name";
+"APPLICATION_NOT_RESPONDING" = "Programm reagiert nicht";
+"PREFS" = "Einstellungen...";
+"DISPLAY_AS" = "Anzeigen als";
+"HIDE" = "Ausblenden";
+"HIDE_NAME" = "%@ ausblenden";
+"HIDE_OTHERS" = "Andere ausblenden";
+"OPEN_AT_LOGIN" = "Bei der Anmeldung öffnen";
+"OPTIONS" = "Optionen";
+"QUIT" = "Beenden";
+"SHOW_IN_FINDER" = "Im Finder anzeigen";
+"SORT_BY" = "Sortiert nach";
+"TURN_NOTIFICATIONS_OFF" = "Benachrichtigungen ausschalten";
+"TURN_NOTIFICATIONS_ON" = "Benachrichtigungen einschalten";
+"WELCOME_TO_LOADING" = "Willkommen bei Loading!";
+"LOADING_INTRO" = "Loading zeigt Ihnen an, wann Apps auf das Internet zugreifen. Möchten Sie, dass Loading gestartet wird, wenn Sie sich anmelden?";
+
+"CANCEL" = "Abbrechen";
+"LOADING" = "Loading";
+"LOADED" = "Zuvor geladen";
+
+"APPLICATIONS" = "Programme";
+"SYSTEM" = "System";
+
+"CHECK_FOR_UPDATES" = "Nach Updates suchen";
+"SEND_FEEDBACK" = "Feedback geben...";
+"ABOUT" = "Über %@";
+"THANKS" = "Vielen Dank!";
+
+"MORE_INFO" = "Weitere Infos...";
+"DOWNLOAD" = "Laden";
+"NAME" = "Name";


### PR DESCRIPTION
The original German (machine?) translation wasn’t very good and only just intelligible. I tried to enhance it as good as I could in a first attempt. (I am a German native speaker.) I sticked with "Loading" as a) it is well known as a term for the process of downloading data in German and "Laden" does not convey that it is something that is going on right now and b) the "LOADING" string obviously is used as name of the app in the Options > About menu. (The actual fix would be to differentiate here between strings for the process of loading and the name Loading. Once these strings are differentiated, another way to translate "loading" and "loaded" more elegantly might be "Aktiv" and "Zuvor aktiv".) I haven’t checked where "DOWNLOAD" is used, but I guess it is for the download of an update, so "Laden" is okay, I guess, at least in contemporary colloquial German.
(Finally, may I add that the German app description on the app’s homepage is quite horrible as well?)
