### PR TITLE
Update FR Localizable.strings

### DIFF
--- a/Loading/fr.lproj/Localizable.strings
+++ b/Loading/fr.lproj/Localizable.strings
@@ -1,1 +1,31 @@
-"APPLICATION_NOT_RESPONDING" = "L’application ne répond pas";"PREFS" = "Préférences...";"DISPLAY_AS" = "Afficher comme";"HIDE" = "Masquer";"HIDE_NAME" = "Masquer %@";"HIDE_OTHERS" = "Masquer les autres";"OPEN_AT_LOGIN" = "Ouvrir avec la session";"OPTIONS" = "Options";"QUIT" = "Quitter";"SHOW_IN_FINDER" = "Afficher dans le Finder";"SORT_BY" = "Trier par";"TURN_NOTIFICATIONS_OFF" = "Désactiver les notifications";"TURN_NOTIFICATIONS_ON" = "Activer les notifications";"WELCOME_TO_LOADING" = "Bienvenue à Loading!";"LOADING_INTRO" = "Loading vous montre quand applications utilisent Internet. Voulez-vous pour ouvrir lorsque vous vous connectez?";"CANCEL" = "Annuler";"LOADING" = "Chargement en cours";"LOADED" = "Chargé";"APPLICATIONS" = "Applications";"SYSTEM" = "Système";"CHECK_FOR_UPDATES" = "Recherche des mises à jour";"SEND_FEEDBACK" = "Donner de la rétroaction...";"ABOUT" = "À propos de %@";"THANKS" = "Merci!";"MORE_INFO" = "En savoir plus...";"DOWNLOAD" = "Télécharger";"NAME" = "Nom";
+"APPLICATION_NOT_RESPONDING" = "L’application ne répond pas";
+"PREFS" = "Préférences...";
+"DISPLAY_AS" = "Afficher comme";
+"HIDE" = "Masquer";
+"HIDE_NAME" = "Masquer Loading";
+"HIDE_OTHERS" = "Masquer les autres";
+"OPEN_AT_LOGIN" = "Démarrer avec la session";
+"OPTIONS" = "Options";
+"QUIT" = "Quitter";
+"SHOW_IN_FINDER" = "Afficher dans le Finder";
+"SORT_BY" = "Trier par";
+"TURN_NOTIFICATIONS_OFF" = "Désactiver les notifications";
+"TURN_NOTIFICATIONS_ON" = "Activer les notifications";
+"WELCOME_TO_LOADING" = "Bienvenue - Loading !";
+"LOADING_INTRO" = "Loading surveille les activités réseaux des applications. Voulez-vous démarrer Loading avec la session ?";
+
+"CANCEL" = "Annuler";
+"LOADING" = "En cours";
+"LOADED" = "Récemment";
+
+"APPLICATIONS" = "Applications";
+"SYSTEM" = "Système";
+
+"CHECK_FOR_UPDATES" = "Vérifier les mises à jour";
+"SEND_FEEDBACK" = "Envoyer un commentaire...";
+"ABOUT" = "À propos de Loading";
+"THANKS" = "Merci !";
+
+"MORE_INFO" = "En savoir plus...";
+"DOWNLOAD" = "Télécharger";
+"NAME" = "Nom";


### PR DESCRIPTION
I had to replace %@ because it was not showing the 'untranslated' app name, "Loading".

It is better to keep one name for the application in all languages. like all the apps on Mac.

To avoid French nightmare with pluralsssss
I have replaced "loading/loaded" header menu items by Currently and Recently.

So I had to change infoplist too.

CFBundleName = "Loading";
CFBundleDisplayName = "Loading";
NSHumanReadableCopyright = "© 2015 Mike McFadden / Bonzai Applications\nTous droits réservés.";
